### PR TITLE
feat(ssh): 注入每台机器记忆上下文

### DIFF
--- a/app/src/ai/agent/api.rs
+++ b/app/src/ai/agent/api.rs
@@ -29,6 +29,7 @@ use super::{AIAgentInput, MCPContext, MCPServer, RequestMetadata, RunningCommand
 use crate::ai::blocklist::{BlocklistAIPermissions, RequestInput};
 use crate::ai::execution_profiles::profiles::AIExecutionProfilesModel;
 use crate::ai::facts::{AIFact, AIFactObjectModel};
+use crate::ai::machine_memory::{self, MachineMemoryContext};
 use crate::ai::mcp::templatable_manager::TemplatableMCPServerInfo;
 use crate::ai::mcp::TemplatableMCPServerManager;
 use crate::cloud_object::model::generic_string_model::GenericStringObjectId;
@@ -89,6 +90,7 @@ pub struct RequestParams {
     pub cli_agent_model: LLMId,
     pub computer_use_model: LLMId,
     pub is_memory_enabled: bool,
+    pub machine_memory: Option<MachineMemoryContext>,
     /// Zap BYOP 专用:用户在 设置 → Agents → Rules 创建的全局 Rules
     /// (`AIFact::Memory`)的快照,在 `new()` 中从 `ObjectStoreModel` 一次性拉取
     /// 后随请求 plumb 到 `chat_stream::build_chat_request` → `prompt_renderer`,
@@ -211,6 +213,7 @@ impl RequestParams {
             cli_agent_model: LLMId::from("byop:test"),
             computer_use_model: LLMId::from("byop:test"),
             is_memory_enabled: false,
+            machine_memory: None,
             user_rules: Vec::new(),
             warp_drive_context_enabled: false,
             context_window_limit: None,
@@ -248,6 +251,7 @@ impl RequestParams {
     ) -> Self {
         let ai_settings = AISettings::as_ref(app);
         let is_memory_enabled = ai_settings.is_memory_enabled(app);
+        let machine_memory = machine_memory::load_for_session(&session_context, app);
         let warp_drive_context_enabled = ai_settings.is_warp_drive_context_enabled(app);
 
         // Zap BYOP 修复 Issue #116:gate 在 `is_memory_enabled`,具体收集逻辑
@@ -412,6 +416,7 @@ impl RequestParams {
             cli_agent_model: request_input.cli_agent_model_id.clone(),
             computer_use_model: request_input.computer_use_model_id.clone(),
             is_memory_enabled,
+            machine_memory,
             user_rules,
             warp_drive_context_enabled,
             mcp_context,

--- a/app/src/ai/agent_providers/chat_stream.rs
+++ b/app/src/ai/agent_providers/chat_stream.rs
@@ -192,6 +192,30 @@ fn render_ssh_session_block(
     ))
 }
 
+fn render_machine_memory_block(
+    machine_memory: Option<&crate::ai::machine_memory::MachineMemoryContext>,
+) -> Option<String> {
+    let machine_memory = machine_memory?;
+    let machine_key = xml_attr(&machine_memory.machine_key);
+    let content = if machine_memory.content.is_empty() {
+        "(no memory recorded for this machine yet)".to_owned()
+    } else {
+        xml_text(&machine_memory.content)
+    };
+
+    Some(format!(
+        "\n\n<machine_memory machine_key=\"{machine_key}\">\n  \
+         <fact>Accumulated notes from previous sessions on this same remote machine.\n  \
+         They may be stale — verify before relying on them for destructive actions.</fact>\n  \
+         <content>\n{content}\n  </content>\n  \
+         <rules>\n  \
+         - When you learn a durable fact about THIS machine (OS/services layout, deploy conventions, gotchas, non-standard paths), call `update_machine_memory` with the full revised memory document.\n  \
+         - Never store credentials, tokens or private keys in machine memory.\n  \
+         </rules>\n\
+         </machine_memory>"
+    ))
+}
+
 /// XML 转义,同时 strip 所有非法/有问题的控制字符,避免 JSON 序列化失败。
 ///
 /// `grid_contents`(从 `formatted_terminal_contents_for_input` 提取的 alt-screen 内容)
@@ -1195,6 +1219,10 @@ fn build_chat_request(
     // 追加一段 SSH 状态块矫正 LLM 推断。
     if let Some(ssh_block) = render_ssh_session_block(&params.session_context) {
         system_text.push_str(&ssh_block);
+    }
+    if let Some(machine_memory_block) = render_machine_memory_block(params.machine_memory.as_ref())
+    {
+        system_text.push_str(&machine_memory_block);
     }
     // 注:LRC / 长命令的工具用法引导(write_to_long_running_shell_command + command_id +
     // 各种 mode 与 raw 字节序列)已经在 `prompts/system/default.j2:69-79` 完整覆盖。
@@ -7781,3 +7809,7 @@ mod issue_94_task_linearization_tests {
         assert_eq!(message_ids(&out), vec!["m1", "m2", "m3"]);
     }
 }
+
+#[cfg(test)]
+#[path = "chat_stream_machine_memory_tests.rs"]
+mod machine_memory_tests;

--- a/app/src/ai/agent_providers/chat_stream_machine_memory_tests.rs
+++ b/app/src/ai/agent_providers/chat_stream_machine_memory_tests.rs
@@ -1,0 +1,47 @@
+use super::*;
+use crate::ai::machine_memory::MachineMemoryContext;
+
+#[test]
+fn render_machine_memory_block_none() {
+    assert_eq!(render_machine_memory_block(None), None);
+}
+
+#[test]
+fn render_machine_memory_block_empty() {
+    let context = MachineMemoryContext {
+        machine_key: "web-01:&\"".to_owned(),
+        content: String::new(),
+    };
+    assert_eq!(
+        render_machine_memory_block(Some(&context)).unwrap(),
+        "\n\n<machine_memory machine_key=\"web-01:&amp;&quot;\">\n  \
+         <fact>Accumulated notes from previous sessions on this same remote machine.\n  \
+         They may be stale — verify before relying on them for destructive actions.</fact>\n  \
+         <content>\n(no memory recorded for this machine yet)\n  </content>\n  \
+         <rules>\n  \
+         - When you learn a durable fact about THIS machine (OS/services layout, deploy conventions, gotchas, non-standard paths), call `update_machine_memory` with the full revised memory document.\n  \
+         - Never store credentials, tokens or private keys in machine memory.\n  \
+         </rules>\n\
+         </machine_memory>"
+    );
+}
+
+#[test]
+fn render_machine_memory_block_non_empty() {
+    let context = MachineMemoryContext {
+        machine_key: "web-01:22".to_owned(),
+        content: "## Services\nnginx lives in /opt/nginx & uses <custom.conf>".to_owned(),
+    };
+    assert_eq!(
+        render_machine_memory_block(Some(&context)).unwrap(),
+        "\n\n<machine_memory machine_key=\"web-01:22\">\n  \
+         <fact>Accumulated notes from previous sessions on this same remote machine.\n  \
+         They may be stale — verify before relying on them for destructive actions.</fact>\n  \
+         <content>\n## Services\nnginx lives in /opt/nginx &amp; uses &lt;custom.conf&gt;\n  </content>\n  \
+         <rules>\n  \
+         - When you learn a durable fact about THIS machine (OS/services layout, deploy conventions, gotchas, non-standard paths), call `update_machine_memory` with the full revised memory document.\n  \
+         - Never store credentials, tokens or private keys in machine memory.\n  \
+         </rules>\n\
+         </machine_memory>"
+    );
+}

--- a/app/src/ai/machine_memory/mod.rs
+++ b/app/src/ai/machine_memory/mod.rs
@@ -1,0 +1,74 @@
+//! Legacy SSH 会话的每机器 AI 记忆加载。
+
+use std::fmt::Display;
+
+use warp_ssh_manager::{resolve_machine_key, MachineMemoryRepository};
+use warpui::{AppContext, SingletonEntity as _};
+
+use crate::ai::blocklist::SessionContext;
+use crate::settings::AISettings;
+use crate::terminal::ssh::util::InteractiveSshCommand;
+
+pub const INJECT_MAX_CHARS: usize = 6_000;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MachineMemoryContext {
+    pub machine_key: String,
+    /// 注入 prompt 的内容，已按 Unicode 字符截断。
+    pub content: String,
+}
+
+/// 仅为可定位机器的 legacy SSH 会话加载记忆。
+pub fn load_for_session(
+    session_context: &SessionContext,
+    ctx: &AppContext,
+) -> Option<MachineMemoryContext> {
+    load_with(
+        AISettings::as_ref(ctx).is_ssh_machine_memory_enabled(ctx),
+        session_context.is_legacy_ssh(),
+        session_context.ssh_connection_info(),
+        |machine_key| {
+            warp_ssh_manager::with_conn(|conn| {
+                Ok(MachineMemoryRepository::get(conn, machine_key)?.map(|memory| memory.content))
+            })
+        },
+    )
+}
+
+fn load_with<E>(
+    enabled: bool,
+    is_legacy_ssh: bool,
+    ssh_connection_info: Option<&InteractiveSshCommand>,
+    load_content: impl FnOnce(&str) -> Result<Option<String>, E>,
+) -> Option<MachineMemoryContext>
+where
+    E: Display,
+{
+    if !enabled || !is_legacy_ssh {
+        return None;
+    }
+
+    let info = ssh_connection_info?;
+    let machine_key = resolve_machine_key(info.host.as_deref(), info.port.as_deref())?;
+    let content = match load_content(&machine_key) {
+        Ok(Some(content)) => truncate_for_injection(&content),
+        Ok(None) => String::new(),
+        Err(err) => {
+            log::warn!("machine memory load failed for {machine_key}: {err}");
+            return None;
+        }
+    };
+
+    Some(MachineMemoryContext {
+        machine_key,
+        content,
+    })
+}
+
+fn truncate_for_injection(content: &str) -> String {
+    content.chars().take(INJECT_MAX_CHARS).collect()
+}
+
+#[cfg(test)]
+#[path = "mod_tests.rs"]
+mod tests;

--- a/app/src/ai/machine_memory/mod_tests.rs
+++ b/app/src/ai/machine_memory/mod_tests.rs
@@ -1,0 +1,61 @@
+use anyhow::anyhow;
+
+use super::*;
+
+fn ssh_info() -> InteractiveSshCommand {
+    InteractiveSshCommand {
+        host: Some("root@Web-01".to_owned()),
+        port: None,
+    }
+}
+
+#[test]
+fn disabled_or_non_legacy_session_skips_loading() {
+    let info = ssh_info();
+    assert_eq!(
+        load_with(false, true, Some(&info), |_| -> anyhow::Result<_> {
+            panic!("disabled setting must not access the database")
+        }),
+        None
+    );
+    assert_eq!(
+        load_with(true, false, Some(&info), |_| -> anyhow::Result<_> {
+            panic!("local sessions must not access the database")
+        }),
+        None
+    );
+}
+
+#[test]
+fn missing_memory_keeps_machine_identity_with_empty_content() {
+    let info = ssh_info();
+    let context = load_with(true, true, Some(&info), |_| Ok::<_, anyhow::Error>(None)).unwrap();
+    assert_eq!(
+        context,
+        MachineMemoryContext {
+            machine_key: "web-01:22".to_owned(),
+            content: String::new(),
+        }
+    );
+}
+
+#[test]
+fn loaded_memory_is_truncated_on_unicode_boundaries() {
+    let info = ssh_info();
+    let content = "机".repeat(INJECT_MAX_CHARS + 1);
+    let context = load_with(true, true, Some(&info), |_| {
+        Ok::<_, anyhow::Error>(Some(content))
+    })
+    .unwrap();
+    assert_eq!(context.content.chars().count(), INJECT_MAX_CHARS);
+    assert_eq!(context.content, "机".repeat(INJECT_MAX_CHARS));
+}
+
+#[test]
+fn database_error_degrades_to_no_memory_context() {
+    let info = ssh_info();
+    let context = load_with(true, true, Some(&info), |_| {
+        Err::<Option<String>, _>(anyhow!("no such table: ssh_machine_memories"))
+    });
+    assert_eq!(context, None);
+}

--- a/app/src/ai/mod.rs
+++ b/app/src/ai/mod.rs
@@ -26,6 +26,7 @@ pub(crate) mod conversation_utils;
 pub(crate) mod document;
 pub(crate) mod harness_display;
 pub(crate) mod llms;
+pub(crate) mod machine_memory;
 pub mod onboarding;
 pub(crate) mod predict;
 pub(crate) mod project_rules_persister;

--- a/app/src/settings/ai.rs
+++ b/app/src/settings/ai.rs
@@ -1529,6 +1529,16 @@ define_settings_group!(AISettings, settings: [
         toml_path: "agents.knowledge.rules_enabled",
         description: "Whether the agent uses your saved rules during requests.",
     }
+    // legacy SSH 会话是否使用每机器记忆。
+    ssh_machine_memory_enabled: SshMachineMemoryEnabled {
+        type: bool,
+        default: true,
+        supported_platforms: SupportedPlatforms::ALL,
+        sync_to_cloud: SyncToCloud::Globally(RespectUserSyncSetting::Yes),
+        private: false,
+        toml_path: "agents.knowledge.ssh_machine_memory_enabled",
+        description: "Whether the agent uses per-machine memory in legacy SSH sessions.",
+    }
     // Whether zap drive context should be included in AI requests
     warp_drive_context_enabled: WarpDriveContextEnabled {
         type: bool,
@@ -2109,6 +2119,10 @@ impl AISettings {
 
     pub fn is_memory_enabled(&self, app: &warpui::AppContext) -> bool {
         self.is_any_ai_enabled(app) && *self.memory_enabled
+    }
+
+    pub fn is_ssh_machine_memory_enabled(&self, app: &warpui::AppContext) -> bool {
+        self.is_memory_enabled(app) && *self.ssh_machine_memory_enabled
     }
 
     pub fn is_warp_drive_context_enabled(&self, app: &warpui::AppContext) -> bool {

--- a/app/src/settings/ai_tests.rs
+++ b/app/src/settings/ai_tests.rs
@@ -382,6 +382,38 @@ fn test_toolbar_command_map_matched_agent() {
 }
 
 #[test]
+fn ssh_machine_memory_setting_respects_memory_master_switch() {
+    App::test((), |mut app| async move {
+        initialize_settings_for_tests(&mut app);
+
+        AISettings::handle(&app).read(&app, |settings, ctx| {
+            assert!(settings.is_ssh_machine_memory_enabled(ctx));
+        });
+
+        AISettings::handle(&app).update(&mut app, |settings, ctx| {
+            settings
+                .ssh_machine_memory_enabled
+                .set_value(false, ctx)
+                .unwrap();
+        });
+        AISettings::handle(&app).read(&app, |settings, ctx| {
+            assert!(!settings.is_ssh_machine_memory_enabled(ctx));
+        });
+
+        AISettings::handle(&app).update(&mut app, |settings, ctx| {
+            settings
+                .ssh_machine_memory_enabled
+                .set_value(true, ctx)
+                .unwrap();
+            settings.memory_enabled.set_value(false, ctx).unwrap();
+        });
+        AISettings::handle(&app).read(&app, |settings, ctx| {
+            assert!(!settings.is_ssh_machine_memory_enabled(ctx));
+        });
+    });
+}
+
+#[test]
 fn test_should_display_quota_reset_banner_with_empty_history() {
     App::test((), |mut app| async move {
         initialize_settings_for_tests(&mut app);

--- a/crates/warp_ssh_manager/src/db.rs
+++ b/crates/warp_ssh_manager/src/db.rs
@@ -19,7 +19,7 @@ use std::path::PathBuf;
 use std::sync::{Mutex, OnceLock};
 
 static DB_PATH: OnceLock<PathBuf> = OnceLock::new();
-static CONN: OnceLock<Mutex<SqliteConnection>> = OnceLock::new();
+static CONN: OnceLock<Mutex<Option<SqliteConnection>>> = OnceLock::new();
 
 /// 由 app 启动时调用一次,传入 sqlite db 文件路径。重复调用会被忽略
 /// (OnceLock 语义)。
@@ -43,9 +43,15 @@ fn open() -> Result<SqliteConnection> {
 
 /// 锁内执行闭包。首次调用时 lazy 打开连接;后续调用复用。
 pub fn with_conn<R>(f: impl FnOnce(&mut SqliteConnection) -> Result<R>) -> Result<R> {
-    let mtx = CONN.get_or_init(|| Mutex::new(open().expect("warp_ssh_manager db open")));
+    let mtx = CONN.get_or_init(|| Mutex::new(None));
     let mut guard = mtx
         .lock()
         .map_err(|_| anyhow!("warp_ssh_manager db mutex poisoned"))?;
-    f(&mut guard)
+    if guard.is_none() {
+        *guard = Some(open()?);
+    }
+    let conn = guard
+        .as_mut()
+        .ok_or_else(|| anyhow!("warp_ssh_manager db connection unavailable"))?;
+    f(conn)
 }

--- a/specs/ssh-machine-memory/TECH.md
+++ b/specs/ssh-machine-memory/TECH.md
@@ -15,16 +15,18 @@ crates/persistence/
 └── src/model.rs                                             (修改 — Task 1)
 
 crates/warp_ssh_manager/src/
+├── db.rs                           (修改 — Task 2：首次打开失败可降级)
 ├── lib.rs                          (修改 — 导出新模块)
 ├── memory.rs                       (NEW — Task 1：类型 + repository + key 归一化)
 └── sync_provider.rs                (修改 — Task 6：同步新表)
 
 app/src/ai/machine_memory/          (NEW — Task 2/4)
-├── mod.rs                          (加载/注入辅助 + 设置项)
+├── mod.rs                          (加载辅助)
 └── review.rs                       (Task 4 — 后台复盘)
 
+app/src/ai/agent/api.rs             (修改 — Task 2/5：RequestParams 增字段)
+app/src/settings/ai.rs               (修改 — Task 2：AI 设置项)
 app/src/ai/agent_providers/
-├── api.rs                          (修改 — Task 2：RequestParams 增字段)
 ├── chat_stream.rs                  (修改 — Task 2 注入；Task 3 工具拦截)
 ├── tools/mod.rs                    (修改 — Task 3：REGISTRY 注册)
 ├── tools/machine_memory.rs         (NEW — Task 3)
@@ -144,16 +146,24 @@ pub struct MachineMemoryContext {
 /// → warp_ssh_manager::with_conn(|c| MachineMemoryRepository::get(...))。
 /// 机器无记忆时也返回 Some（content 空串）——工具可用性（Task 3）依赖 machine_key 存在。
 /// DB 错误：log warn + 返回 None，绝不 panic、不阻塞请求。
-pub fn load_for_session(ctx: &SessionContext) -> Option<MachineMemoryContext>;
+pub fn load_for_session(
+    session_context: &SessionContext,
+    ctx: &AppContext,
+) -> Option<MachineMemoryContext>;
 ```
 
-设置项：在现有 AI 设置处（`AISettings`，`is_memory_enabled` 所在体系）新增
+设置项：在 `app/src/settings/ai.rs` 的现有 AI 设置处（`AISettings`，
+`is_memory_enabled` 所在体系）新增
 `ssh_machine_memory_enabled: bool`，默认 `true`。`load_for_session` 在
 总开关 `is_memory_enabled` 或本开关为 false 时直接返回 None。
 
+`crates/warp_ssh_manager/src/db.rs` 的连接惰性初始化必须传递
+`open()` 错误，不得在 `OnceLock::get_or_init` 内 `expect`；这样未初始化、
+数据库打开失败或表缺失都能在 app 侧统一 warn 后降级。
+
 ### 2.2 RequestParams 增字段
 
-`app/src/ai/agent_providers/api.rs` 的 `RequestParams` 新增
+`app/src/ai/agent/api.rs` 的 `RequestParams` 新增
 `pub machine_memory: Option<MachineMemoryContext>`，在 `RequestParams::new`
 中调用 `load_for_session`（已持有 `session_context`）。
 


### PR DESCRIPTION
## Description

实现 `specs/ssh-machine-memory/TECH.md` Task 2（§2.1-§2.4）：仅在 legacy SSH 会话加载机器记忆，并追加到 system prompt。

- 新增 `MachineMemoryContext` 加载、6,000 字符 Unicode 安全截断与设置 gating
- `RequestParams` 携带机器记忆，chat request 渲染 `<machine_memory>`
- SSH Manager 数据库首次打开失败改为可降级错误，不再 panic
- TECH §0/§2.1/§2.2 按实际模块位置和失败降级约束同步修订

## Testing / Task 2 验收自检

- [x] `cargo check`：实现阶段通过；仅有既有 `app/src/terminal/view.rs` 未使用参数警告
- [x] 渲染三态：`None`、空记忆、非空记忆测试通过
- [x] legacy SSH / 本地会话 gating、总记忆开关、SSH 记忆开关测试覆盖
- [x] DB 缺表/打开错误降级为 `None`，不阻断请求
- [x] 机器无记录时仍保留 machine identity，内容为空，供 Task 3 工具 gating 使用
- [x] Task 5 累计 machine-memory 聚焦测试：30/30 通过（包含本 Task 回归）
- [ ] 手工 network log 验证：未运行；需要交互式 Zap + 测试 SSH 主机

## Spec alignment

无设计偏离。TECH 的模块路径、`AppContext` 参数及 DB lazy-open 失败语义已按实现前发现的实际代码结构修订并随本 PR 提交。

## Server API dependencies

无。

## Agent Mode

- [x] Zap Agent Mode - This PR was created via Zap AI Agent Mode
