### PR TITLE
feat(ssh): 添加机器记忆更新工具

### DIFF
--- a/app/src/ai/agent/api/convert_from.rs
+++ b/app/src/ai/agent/api/convert_from.rs
@@ -141,6 +141,21 @@ impl ConvertAPIMessageToClientOutputMessage for api::Message {
                     ),
                 ))
             }
+            api::message::Message::ToolCall(tool_call)
+                if is_machine_memory_tool_carrier(&tool_call, &self.server_message_data) =>
+            {
+                Ok(MaybeAIAgentOutputMessage::Message(
+                    AIAgentOutputMessage::text(
+                        MessageId::new(self.id),
+                        AIAgentText {
+                            sections: parse_markdown_into_text_and_code_sections(
+                                "Updating machine memory",
+                            ),
+                        },
+                    )
+                    .with_citations(citations),
+                ))
+            }
             api::message::Message::ToolCall(tool_call) => match tool_call.to_action(params)? {
                 MaybeAIAgentAction::Action(action) => Ok(MaybeAIAgentOutputMessage::Message(
                     AIAgentOutputMessage::action(MessageId::new(self.id), action)
@@ -506,6 +521,16 @@ impl ConvertAPIMessageToClientOutputMessage for api::Message {
     }
 }
 
+fn is_machine_memory_tool_carrier(
+    tool_call: &api::message::ToolCall,
+    server_message_data: &str,
+) -> bool {
+    tool_call.tool.is_none()
+        && server_message_data
+            .split_once('\n')
+            .is_some_and(|(name, _)| name == "update_machine_memory")
+}
+
 impl From<api::message::AgentOutput> for AIAgentText {
     fn from(value: api::message::AgentOutput) -> Self {
         AIAgentText {
@@ -823,3 +848,7 @@ fn convert_api_question(
         },
     })
 }
+
+#[cfg(test)]
+#[path = "convert_from_tests.rs"]
+mod tests;

--- a/app/src/ai/agent/api/convert_from_tests.rs
+++ b/app/src/ai/agent/api/convert_from_tests.rs
@@ -1,0 +1,50 @@
+use super::*;
+
+fn carrier_message(name: &str) -> api::Message {
+    api::Message {
+        id: "message-1".to_owned(),
+        task_id: "task-1".to_owned(),
+        server_message_data: format!("{name}\n{{\"content\":\"memory\"}}"),
+        citations: Vec::new(),
+        message: Some(api::message::Message::ToolCall(api::message::ToolCall {
+            tool_call_id: "call-1".to_owned(),
+            tool: None,
+        })),
+        request_id: "request-1".to_owned(),
+        timestamp: None,
+    }
+}
+
+fn conversion_params(task_id: &TaskId) -> ConversionParams<'_> {
+    ConversionParams {
+        task_id,
+        current_todo_list: None,
+        active_code_review: None,
+    }
+}
+
+#[test]
+fn machine_memory_carrier_has_visible_neutral_message() {
+    let task_id = TaskId::new("task-1".to_owned());
+    let output = carrier_message("update_machine_memory")
+        .to_client_output_message(conversion_params(&task_id))
+        .unwrap();
+
+    let MaybeAIAgentOutputMessage::Message(output) = output else {
+        panic!("machine memory carrier must have a client representation");
+    };
+    assert_eq!(output.to_string(), "Updating machine memory");
+}
+
+#[test]
+fn unrelated_empty_tool_carrier_remains_hidden() {
+    let task_id = TaskId::new("task-1".to_owned());
+    let output = carrier_message("some_other_local_tool")
+        .to_client_output_message(conversion_params(&task_id))
+        .unwrap();
+
+    assert!(matches!(
+        output,
+        MaybeAIAgentOutputMessage::NoClientRepresentation
+    ));
+}

--- a/app/src/ai/agent_providers/chat_stream.rs
+++ b/app/src/ai/agent_providers/chat_stream.rs
@@ -2707,6 +2707,9 @@ pub fn available_tool_names(params: &RequestParams) -> Vec<String> {
             {
                 return false;
             }
+            if params.machine_memory.is_none() && t.name == tools::machine_memory::TOOL_NAME {
+                return false;
+            }
             if t.name == "suggest_new_conversation" {
                 return false;
             }
@@ -2764,6 +2767,10 @@ fn build_tools_array(params: &RequestParams) -> Vec<GenaiTool> {
             if !web_enabled
                 && (t.name == tools::webfetch::TOOL_NAME || t.name == tools::websearch::TOOL_NAME)
             {
+                return false;
+            }
+            // Zap:机器记忆工具只属于可定位机器的 legacy SSH 会话。
+            if params.machine_memory.is_none() && t.name == tools::machine_memory::TOOL_NAME {
                 return false;
             }
             // suggest_new_conversation:无 UI 实现,executor 在 Zap 改为
@@ -3950,11 +3957,12 @@ pub async fn generate_byop_output(
                     // 增量刷新 args,长 args 工具(create_or_edit_document、长 grep 等)体感连续。
                     // web 工具(webfetch/websearch)走自己的 loading 帧链路(L2102 区域),
                     // 这里跳过避免双卡。
-                    // todowrite 走 BYOP todo 拦截器,合成 Message::UpdateTodos 触发 chip,
-                    // 这里也跳过占位避免出现一张无意义的"调用 todowrite"卡。
+                    // todowrite / update_machine_memory 走 BYOP 本地拦截器，
+                    // 这里跳过无法转换为 action 的占位卡。
                     if call.fn_name != tools::webfetch::TOOL_NAME
                         && call.fn_name != tools::websearch::TOOL_NAME
                         && call.fn_name != tools::todowrite::TOOL_NAME
+                        && call.fn_name != tools::machine_memory::TOOL_NAME
                     {
                         if let Some(msg_id) = tool_msg_ids.get(&call.call_id).cloned() {
                             // 已 emit 占位 → 节流增量刷新。
@@ -4330,6 +4338,37 @@ pub async fn generate_byop_output(
                         ));
                     }
                 }
+                continue;
+            }
+
+            // Zap BYOP 机器记忆拦截:不映射 protobuf executor,直接写本地数据库，
+            // 再合成 carrier ToolCall + ToolCallResult 给模型继续下一轮。
+            if call.fn_name == tools::machine_memory::TOOL_NAME {
+                let args_str = if call.fn_arguments.is_string() {
+                    call.fn_arguments.as_str().unwrap_or("").to_owned()
+                } else {
+                    call.fn_arguments.to_string()
+                };
+                let result_json = dispatch_byop_machine_memory_tool(
+                    params.machine_memory.as_ref(),
+                    &args_str,
+                );
+                let result_content = serde_json::to_string(&result_json).unwrap_or_else(|_| {
+                    r#"{"_byop_intercepted":true,"status":"error","message":"failed to serialize result"}"#.to_owned()
+                });
+                final_messages.push(make_tool_call_carrier_message(
+                    &current_task_id,
+                    &request_id,
+                    &call.call_id,
+                    &call.fn_name,
+                    &args_str,
+                ));
+                final_messages.push(make_tool_call_result_message(
+                    &current_task_id,
+                    &request_id,
+                    call.call_id.clone(),
+                    result_content,
+                ));
                 continue;
             }
 
@@ -4789,6 +4828,51 @@ fn make_append_event(task_id: &str, message_id: &str, kind: AppendKind) -> api::
                 }],
             },
         )),
+    }
+}
+
+/// Zap BYOP `update_machine_memory` 的本地分发器。
+fn dispatch_byop_machine_memory_tool(
+    memory: Option<&crate::ai::machine_memory::MachineMemoryContext>,
+    args_str: &str,
+) -> Value {
+    dispatch_byop_machine_memory_tool_with(memory, args_str, |machine_key, content| {
+        warp_ssh_manager::with_conn(|conn| {
+            warp_ssh_manager::MachineMemoryRepository::upsert_content(conn, machine_key, content)?;
+            Ok(())
+        })
+    })
+}
+
+fn dispatch_byop_machine_memory_tool_with<E>(
+    memory: Option<&crate::ai::machine_memory::MachineMemoryContext>,
+    args_str: &str,
+    write: impl FnOnce(&str, &str) -> Result<(), E>,
+) -> Value
+where
+    E: std::fmt::Display,
+{
+    let args = match tools::machine_memory::parse_args(args_str) {
+        Ok(args) => args,
+        Err(error) => {
+            log::warn!("[byop][machine-memory] invalid arguments: {error:#}");
+            return tools::machine_memory::invalid_arguments_result_to_json(error.to_string());
+        }
+    };
+    let Some(memory) = memory else {
+        return tools::machine_memory::missing_machine_key_result_to_json();
+    };
+    let content = tools::machine_memory::truncate_content(&args.content);
+    let stored_chars = content.chars().count();
+    match write(&memory.machine_key, &content) {
+        Ok(()) => tools::machine_memory::success_result_to_json(stored_chars),
+        Err(error) => {
+            log::warn!(
+                "[byop][machine-memory] write failed for {}: {error}",
+                memory.machine_key
+            );
+            tools::machine_memory::error_result_to_json("failed to update machine memory")
+        }
     }
 }
 

--- a/app/src/ai/agent_providers/chat_stream_machine_memory_tests.rs
+++ b/app/src/ai/agent_providers/chat_stream_machine_memory_tests.rs
@@ -45,3 +45,86 @@ fn render_machine_memory_block_non_empty() {
          </machine_memory>"
     );
 }
+
+#[test]
+fn machine_memory_tool_is_gated_by_machine_context() {
+    let mut params = RequestParams::new_for_test(Vec::new(), Vec::new());
+
+    assert!(!available_tool_names(&params)
+        .iter()
+        .any(|name| name == tools::machine_memory::TOOL_NAME));
+    assert!(!build_tools_array(&params)
+        .iter()
+        .any(|tool| tool.name == tools::machine_memory::TOOL_NAME.into()));
+
+    params.machine_memory = Some(MachineMemoryContext {
+        machine_key: "web-01:22".to_owned(),
+        content: String::new(),
+    });
+
+    assert!(available_tool_names(&params)
+        .iter()
+        .any(|name| name == tools::machine_memory::TOOL_NAME));
+    assert!(build_tools_array(&params)
+        .iter()
+        .any(|tool| tool.name == tools::machine_memory::TOOL_NAME.into()));
+}
+
+#[test]
+fn missing_machine_context_returns_intercepted_error_without_writing() {
+    let result = dispatch_byop_machine_memory_tool_with(
+        None,
+        r#"{"content":"remember me"}"#,
+        |_, _| -> Result<(), &'static str> { panic!("missing key must not write") },
+    );
+
+    assert_eq!(result["_byop_intercepted"], true);
+    assert_eq!(result["status"], "error");
+    assert_eq!(
+        result["message"],
+        "not in an ssh session with machine identity"
+    );
+}
+
+#[test]
+fn dispatch_truncates_unicode_and_reports_stored_character_count() {
+    let memory = MachineMemoryContext {
+        machine_key: "web-01:22".to_owned(),
+        content: String::new(),
+    };
+    let args = serde_json::json!({
+        "content": "机".repeat(warp_ssh_manager::MAX_MEMORY_CHARS + 1),
+    })
+    .to_string();
+    let mut written = None;
+
+    let result =
+        dispatch_byop_machine_memory_tool_with(Some(&memory), &args, |machine_key, content| {
+            written = Some((machine_key.to_owned(), content.to_owned()));
+            Ok::<(), &'static str>(())
+        });
+
+    let (machine_key, content) = written.unwrap();
+    assert_eq!(machine_key, "web-01:22");
+    assert_eq!(content.chars().count(), warp_ssh_manager::MAX_MEMORY_CHARS);
+    assert_eq!(result["_byop_intercepted"], true);
+    assert_eq!(result["status"], "ok");
+    assert_eq!(result["stored_chars"], warp_ssh_manager::MAX_MEMORY_CHARS);
+}
+
+#[test]
+fn dispatch_database_error_keeps_auto_resume_sentinel() {
+    let memory = MachineMemoryContext {
+        machine_key: "web-01:22".to_owned(),
+        content: String::new(),
+    };
+    let result = dispatch_byop_machine_memory_tool_with(
+        Some(&memory),
+        r#"{"content":"remember me"}"#,
+        |_, _| Err("database unavailable"),
+    );
+
+    assert_eq!(result["_byop_intercepted"], true);
+    assert_eq!(result["status"], "error");
+    assert_eq!(result["message"], "failed to update machine memory");
+}

--- a/app/src/ai/agent_providers/prompts/tool_descriptions/update_machine_memory.md
+++ b/app/src/ai/agent_providers/prompts/tool_descriptions/update_machine_memory.md
@@ -1,0 +1,14 @@
+Replace the complete persistent AI memory document for the current remote SSH machine.
+
+Use this tool only for durable facts that will help in future sessions on this same machine, such as:
+- operating system and service layout;
+- deployment conventions and non-standard paths;
+- stable operational practices;
+- machine-specific gotchas that are likely to recur.
+
+Calling rules:
+- Always pass the full revised memory document. Each call replaces the previously stored document; it does not append to it.
+- Keep the document at or below 16,000 Unicode characters. Longer content will be truncated.
+- Never store passwords, tokens, private keys, credentials, or other secrets.
+- Do not record one-time commands, transient command output, session logs, or a chronological account of work performed.
+- Preserve still-valid prior facts, merge duplicates, and replace stale facts when new evidence disproves them.

--- a/app/src/ai/agent_providers/tools/machine_memory.rs
+++ b/app/src/ai/agent_providers/tools/machine_memory.rs
@@ -1,0 +1,92 @@
+//! Zap: `update_machine_memory` BYOP 本地拦截工具 descriptor。
+//!
+//! 该工具不映射 protobuf executor variant。`chat_stream.rs` 会在
+//! `parse_incoming_tool_call` 前按名称拦截，解析完整记忆文档并写入本地数据库。
+
+use anyhow::{anyhow, Result};
+use serde::Deserialize;
+use serde_json::{json, Value};
+use warp_multi_agent_api as api;
+use warp_ssh_manager::memory::MAX_MEMORY_CHARS;
+
+use super::OpenAiTool;
+
+pub const TOOL_NAME: &str = "update_machine_memory";
+
+#[derive(Debug, Deserialize, Eq, PartialEq)]
+pub struct Args {
+    pub content: String,
+}
+
+fn parameters() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "content": {
+                "type": "string",
+                "description": "The complete revised machine memory document. This replaces the previously stored document."
+            }
+        },
+        "required": ["content"],
+        "additionalProperties": false
+    })
+}
+
+fn from_args(_args: &str) -> Result<api::message::tool_call::Tool> {
+    Err(anyhow!(
+        "update_machine_memory is intercepted by chat_stream BYOP machine memory dispatcher; \
+         from_args should never be called"
+    ))
+}
+
+fn result_to_json(_result: &api::message::tool_call_result::Result) -> Option<Value> {
+    None
+}
+
+pub static UPDATE_MACHINE_MEMORY: OpenAiTool = OpenAiTool {
+    name: TOOL_NAME,
+    description: include_str!("../prompts/tool_descriptions/update_machine_memory.md"),
+    parameters,
+    from_args,
+    result_to_json,
+};
+
+pub fn parse_args(args: &str) -> Result<Args> {
+    serde_json::from_str(args)
+        .map_err(|error| anyhow!("update_machine_memory args parse error: {error}"))
+}
+
+/// 按 Unicode 字符截断，避免在 CJK 或 emoji 的 UTF-8 编码中间切断。
+pub fn truncate_content(content: &str) -> String {
+    content.chars().take(MAX_MEMORY_CHARS).collect()
+}
+
+/// 本地拦截工具结果必须带 sentinel，controller 才会自动续轮。
+pub fn success_result_to_json(stored_chars: usize) -> Value {
+    json!({
+        "_byop_intercepted": true,
+        "status": "ok",
+        "stored_chars": stored_chars,
+    })
+}
+
+pub fn error_result_to_json(message: impl Into<String>) -> Value {
+    json!({
+        "_byop_intercepted": true,
+        "status": "error",
+        "message": message.into(),
+    })
+}
+
+pub fn missing_machine_key_result_to_json() -> Value {
+    error_result_to_json("not in an ssh session with machine identity")
+}
+
+pub fn invalid_arguments_result_to_json(detail: impl Into<String>) -> Value {
+    let detail = detail.into();
+    error_result_to_json(format!("invalid arguments: {detail}"))
+}
+
+#[cfg(test)]
+#[path = "machine_memory_tests.rs"]
+mod tests;

--- a/app/src/ai/agent_providers/tools/machine_memory_tests.rs
+++ b/app/src/ai/agent_providers/tools/machine_memory_tests.rs
@@ -1,0 +1,62 @@
+use super::*;
+
+fn assert_serialized_sentinel(value: &Value) {
+    assert_eq!(value["_byop_intercepted"], true);
+    let serialized = serde_json::to_string(value).unwrap();
+    assert!(serialized.contains(r#""_byop_intercepted":true"#));
+}
+
+#[test]
+fn parses_complete_memory_document() {
+    let args = parse_args(r###"{"content":"## System\nUbuntu 24.04"}"###).unwrap();
+    assert_eq!(
+        args,
+        Args {
+            content: "## System\nUbuntu 24.04".to_owned(),
+        }
+    );
+}
+
+#[test]
+fn rejects_missing_or_non_string_content() {
+    assert!(parse_args("{}").is_err());
+    assert!(parse_args(r#"{"content":42}"#).is_err());
+}
+
+#[test]
+fn truncates_content_by_unicode_characters() {
+    let input = format!("{}tail", "机".repeat(MAX_MEMORY_CHARS));
+    let truncated = truncate_content(&input);
+
+    assert_eq!(truncated.chars().count(), MAX_MEMORY_CHARS);
+    assert_eq!(truncated, "机".repeat(MAX_MEMORY_CHARS));
+}
+
+#[test]
+fn intercepted_result_payloads_include_auto_resume_sentinel() {
+    let success = success_result_to_json(123);
+    assert_eq!(success["status"], "ok");
+    assert_eq!(success["stored_chars"], 123);
+    assert_serialized_sentinel(&success);
+
+    let missing_key = missing_machine_key_result_to_json();
+    assert_eq!(missing_key["status"], "error");
+    assert_eq!(
+        missing_key["message"],
+        "not in an ssh session with machine identity"
+    );
+    assert_serialized_sentinel(&missing_key);
+
+    let error = error_result_to_json("database unavailable");
+    assert_eq!(error["status"], "error");
+    assert_eq!(error["message"], "database unavailable");
+    assert_serialized_sentinel(&error);
+
+    let invalid = invalid_arguments_result_to_json("missing field `content`");
+    assert_eq!(invalid["status"], "error");
+    assert_eq!(
+        invalid["message"],
+        "invalid arguments: missing field `content`"
+    );
+    assert_serialized_sentinel(&invalid);
+}

--- a/app/src/ai/agent_providers/tools/mod.rs
+++ b/app/src/ai/agent_providers/tools/mod.rs
@@ -26,6 +26,7 @@ pub mod edit;
 pub mod exa;
 pub mod files;
 pub mod long_shell;
+pub mod machine_memory;
 pub mod markers;
 pub mod mcp;
 pub mod search;
@@ -100,6 +101,9 @@ pub const REGISTRY: &[&OpenAiTool] = &[
     // gating:profile.web_search_enabled=false 时,build_tools_array 会过滤掉。
     &webfetch::WEBFETCH,
     &websearch::WEBSEARCH,
+    // Zap:每台 SSH 机器的 AI 记忆,由 chat_stream 本地写库。
+    // gating:仅有 machine_memory 上下文时加入请求 tools 数组。
+    &machine_memory::UPDATE_MACHINE_MEMORY,
 ];
 
 /// 按 OpenAI function name 反查注册表。

--- a/specs/ssh-machine-memory/TECH.md
+++ b/specs/ssh-machine-memory/TECH.md
@@ -242,6 +242,15 @@ executor，chat_stream 在 `parse_incoming_tool_call` 之前按 name 拦截本�
 4. 成功返回 `{"status":"ok","stored_chars":N}`。
 5. **本轮请求内**后续注入内容不需要刷新（下一轮 `RequestParams::new` 自然读到新值）。
 
+成功、参数错误、机器 key 缺失和数据库错误的结果 JSON 都必须包含
+`"_byop_intercepted": true`。该 sentinel 与现有 todowrite/web 工具一致，由
+controller 触发自动续轮，避免本地拦截工具没有 `AIAgentAction` 入队时对话停住。
+
+carrier `ToolCall` 的 `tool` 为 None，现有转换层默认不生成 UI。允许在 app 侧增加
+专用于机器记忆更新的可见 output message：由 `update_machine_memory` carrier 转换，
+复用现有文本渲染显示结果中性的 `Updating machine memory`；不得为此新增 protobuf
+executor variant。
+
 ### 3.4 验收标准
 
 - [ ] SSH 会话中对 Agent 说"记住这台机器 nginx 装在 /opt/nginx"，模型调用工具，
@@ -249,7 +258,10 @@ executor，chat_stream 在 `parse_incoming_tool_call` 之前按 name 拦截本�
 - [ ] 下一次在同一机器新开会话，`<machine_memory>` 块含上述内容。
 - [ ] 本地非 SSH 会话的请求 tools 数组中**无** `update_machine_memory`。
 - [ ] 超长 content 截断不报错；机器 key 缺失时返回错误 JSON 且不崩。
-- [ ] 单元测试：args 解析、截断、gating（对齐 web 工具现有测试）。
+- [ ] 成功与所有错误结果都带 `_byop_intercepted`，controller 能自动续轮；UI
+      能看到机器记忆更新工具调用。
+- [ ] 单元测试：args 解析、截断、gating、缺 key、sentinel 与 app 侧 carrier
+      转换（对齐 web 工具现有测试）。
 
 ---
 


### PR DESCRIPTION
## Description

实现 `specs/ssh-machine-memory/TECH.md` Task 3（§3.1-§3.4）：新增 BYOP 本地工具 `update_machine_memory`，让 Agent 全量替换当前 SSH 机器记忆。

- 注册英文工具描述与 `{ content: string }` 参数 schema
- 仅有 machine identity 时暴露工具，本地拦截写入 repository
- 所有成功/错误结果携带 `_byop_intercepted`，保证 controller 自动续轮
- 增加中性的可见 carrier 输出 `Updating machine memory`，不新增 protobuf executor
- TECH §3.3/§3.4 同步记录 sentinel 与 UI carrier 约束

## Testing / Task 3 验收自检

- [x] args 解析：完整文档、缺失字段、非字符串字段
- [x] Unicode 超长内容按字符截断至 16,000，并回报 `stored_chars`
- [x] 本地非 SSH 请求 tools 数组不包含 `update_machine_memory`
- [x] 缺 machine key 与 DB 错误返回 intercepted error，不崩溃
- [x] 成功及所有错误 payload 都覆盖 `_byop_intercepted`
- [x] carrier 转换产生可见中性消息，其他空 carrier 保持隐藏
- [x] Task 5 累计 machine-memory 聚焦测试：30/30 通过（包含本 Task 回归）
- [ ] 手工 SSH Agent 工具调用及下次会话回读：未运行；需要交互式 Zap + 测试 SSH 主机/模型

## Spec alignment

无未记录偏离。实现前确认本地 intercepted tool 若无 sentinel 会停止续轮、空 carrier 默认无 UI，因此将这两项必要约束补入 TECH 并实现。

## Server API dependencies

无。

## Agent Mode

- [x] Zap Agent Mode - This PR was created via Zap AI Agent Mode
