### PR TITLE
feat(ssh): 注入已知机器索引

### DIFF
--- a/app/src/ai/agent/api.rs
+++ b/app/src/ai/agent/api.rs
@@ -91,6 +91,7 @@ pub struct RequestParams {
     pub computer_use_model: LLMId,
     pub is_memory_enabled: bool,
     pub machine_memory: Option<MachineMemoryContext>,
+    pub machine_index: Option<String>,
     /// Zap BYOP 专用:用户在 设置 → Agents → Rules 创建的全局 Rules
     /// (`AIFact::Memory`)的快照,在 `new()` 中从 `ObjectStoreModel` 一次性拉取
     /// 后随请求 plumb 到 `chat_stream::build_chat_request` → `prompt_renderer`,
@@ -214,6 +215,7 @@ impl RequestParams {
             computer_use_model: LLMId::from("byop:test"),
             is_memory_enabled: false,
             machine_memory: None,
+            machine_index: None,
             user_rules: Vec::new(),
             warp_drive_context_enabled: false,
             context_window_limit: None,
@@ -252,6 +254,7 @@ impl RequestParams {
         let ai_settings = AISettings::as_ref(app);
         let is_memory_enabled = ai_settings.is_memory_enabled(app);
         let machine_memory = machine_memory::load_for_session(&session_context, app);
+        let machine_index = machine_memory::load_index_for_session(&session_context, app);
         let warp_drive_context_enabled = ai_settings.is_warp_drive_context_enabled(app);
 
         // Zap BYOP 修复 Issue #116:gate 在 `is_memory_enabled`,具体收集逻辑
@@ -417,6 +420,7 @@ impl RequestParams {
             computer_use_model: request_input.computer_use_model_id.clone(),
             is_memory_enabled,
             machine_memory,
+            machine_index,
             user_rules,
             warp_drive_context_enabled,
             mcp_context,

--- a/app/src/ai/agent_providers/chat_stream.rs
+++ b/app/src/ai/agent_providers/chat_stream.rs
@@ -216,6 +216,20 @@ fn render_machine_memory_block(
     ))
 }
 
+fn render_known_ssh_machines_block(machine_index: Option<&str>) -> Option<String> {
+    let machine_index = xml_text(machine_index?);
+    Some(format!(
+        "\n\n<known_ssh_machines>\n  \
+         <fact>These are remote SSH machines known from previous sessions. Use this index to identify a machine when the user refers to it by name.</fact>\n  \
+         <machines>\n{machine_index}\n  </machines>\n  \
+         <rules>\n  \
+         - Use the summaries only as potentially stale context; verify before relying on them for destructive actions.\n  \
+         - Connections must be initiated by the user or through SSH Manager. Ask the user to run or suggest that they run `ssh &lt;host&gt;`, using the host portion of the machine key. Never initiate an SSH connection automatically.\n  \
+         </rules>\n\
+         </known_ssh_machines>"
+    ))
+}
+
 /// XML 转义,同时 strip 所有非法/有问题的控制字符,避免 JSON 序列化失败。
 ///
 /// `grid_contents`(从 `formatted_terminal_contents_for_input` 提取的 alt-screen 内容)
@@ -1223,6 +1237,11 @@ fn build_chat_request(
     if let Some(machine_memory_block) = render_machine_memory_block(params.machine_memory.as_ref())
     {
         system_text.push_str(&machine_memory_block);
+    }
+    if let Some(machine_index_block) =
+        render_known_ssh_machines_block(params.machine_index.as_deref())
+    {
+        system_text.push_str(&machine_index_block);
     }
     // 注:LRC / 长命令的工具用法引导(write_to_long_running_shell_command + command_id +
     // 各种 mode 与 raw 字节序列)已经在 `prompts/system/default.j2:69-79` 完整覆盖。

--- a/app/src/ai/agent_providers/chat_stream_machine_memory_tests.rs
+++ b/app/src/ai/agent_providers/chat_stream_machine_memory_tests.rs
@@ -47,6 +47,29 @@ fn render_machine_memory_block_non_empty() {
 }
 
 #[test]
+fn render_known_ssh_machines_block_none() {
+    assert_eq!(render_known_ssh_machines_block(None), None);
+}
+
+#[test]
+fn render_known_ssh_machines_block_escapes_index_and_forbids_auto_connect() {
+    assert_eq!(
+        render_known_ssh_machines_block(Some(
+            "- web-01:22: nginx uses <custom.conf> & /opt/nginx"
+        ))
+        .unwrap(),
+        "\n\n<known_ssh_machines>\n  \
+         <fact>These are remote SSH machines known from previous sessions. Use this index to identify a machine when the user refers to it by name.</fact>\n  \
+         <machines>\n- web-01:22: nginx uses &lt;custom.conf&gt; &amp; /opt/nginx\n  </machines>\n  \
+         <rules>\n  \
+         - Use the summaries only as potentially stale context; verify before relying on them for destructive actions.\n  \
+         - Connections must be initiated by the user or through SSH Manager. Ask the user to run or suggest that they run `ssh &lt;host&gt;`, using the host portion of the machine key. Never initiate an SSH connection automatically.\n  \
+         </rules>\n\
+         </known_ssh_machines>"
+    );
+}
+
+#[test]
 fn machine_memory_tool_is_gated_by_machine_context() {
     let mut params = RequestParams::new_for_test(Vec::new(), Vec::new());
 

--- a/app/src/ai/machine_memory/mod.rs
+++ b/app/src/ai/machine_memory/mod.rs
@@ -4,7 +4,7 @@ pub(crate) mod review;
 
 use std::fmt::Display;
 
-use warp_ssh_manager::{resolve_machine_key, MachineMemoryRepository};
+use warp_ssh_manager::{resolve_machine_key, MachineMemory, MachineMemoryRepository};
 use warpui::{AppContext, SingletonEntity as _};
 
 use crate::ai::blocklist::SessionContext;
@@ -12,6 +12,9 @@ use crate::settings::AISettings;
 use crate::terminal::ssh::util::InteractiveSshCommand;
 
 pub const INJECT_MAX_CHARS: usize = 6_000;
+pub const INDEX_MAX_MACHINES: usize = 30;
+pub const INDEX_SUMMARY_MAX_CHARS: usize = 120;
+pub const INDEX_MAX_CHARS: usize = 3_000;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MachineMemoryContext {
@@ -34,6 +37,19 @@ pub fn load_for_session(
                 Ok(MachineMemoryRepository::get(conn, machine_key)?.map(|memory| memory.content))
             })
         },
+    )
+}
+
+/// 仅为本地非 SSH 会话加载已知机器索引。
+pub fn load_index_for_session(
+    session_context: &SessionContext,
+    ctx: &AppContext,
+) -> Option<String> {
+    load_index_with(
+        AISettings::as_ref(ctx).is_ssh_machine_memory_enabled(ctx),
+        session_context.is_legacy_ssh(),
+        session_context.is_remote(),
+        || warp_ssh_manager::with_conn(|conn| Ok(MachineMemoryRepository::list_all(conn)?)),
     )
 }
 
@@ -69,6 +85,57 @@ where
 
 fn truncate_for_injection(content: &str) -> String {
     content.chars().take(INJECT_MAX_CHARS).collect()
+}
+
+fn load_index_with<E>(
+    enabled: bool,
+    is_legacy_ssh: bool,
+    is_warpified_ssh: bool,
+    load_memories: impl FnOnce() -> Result<Vec<MachineMemory>, E>,
+) -> Option<String>
+where
+    E: Display,
+{
+    if !enabled || is_legacy_ssh || is_warpified_ssh {
+        return None;
+    }
+
+    let memories = match load_memories() {
+        Ok(memories) => memories,
+        Err(err) => {
+            log::warn!("machine memory index load failed: {err}");
+            return None;
+        }
+    };
+    build_machine_index(&memories)
+}
+
+fn build_machine_index(memories: &[MachineMemory]) -> Option<String> {
+    if memories.is_empty() {
+        return None;
+    }
+
+    let mut memories = memories.iter().collect::<Vec<_>>();
+    memories.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+    let index = memories
+        .into_iter()
+        .take(INDEX_MAX_MACHINES)
+        .map(|memory| {
+            let summary = memory
+                .content
+                .lines()
+                .map(str::trim)
+                .find(|line| !line.is_empty())
+                .unwrap_or_default()
+                .chars()
+                .take(INDEX_SUMMARY_MAX_CHARS)
+                .collect::<String>();
+            format!("- {}: {summary}", memory.machine_key)
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    Some(index.chars().take(INDEX_MAX_CHARS).collect())
 }
 
 #[cfg(test)]

--- a/app/src/ai/machine_memory/mod_tests.rs
+++ b/app/src/ai/machine_memory/mod_tests.rs
@@ -1,4 +1,5 @@
 use anyhow::anyhow;
+use chrono::{TimeZone as _, Utc};
 
 use super::*;
 
@@ -58,4 +59,116 @@ fn database_error_degrades_to_no_memory_context() {
         Err::<Option<String>, _>(anyhow!("no such table: ssh_machine_memories"))
     });
     assert_eq!(context, None);
+}
+
+fn memory_at(
+    machine_key: impl Into<String>,
+    content: impl Into<String>,
+    updated_at: i64,
+) -> MachineMemory {
+    MachineMemory {
+        machine_key: machine_key.into(),
+        content: content.into(),
+        hostname_alias: None,
+        ssh_node_id: None,
+        last_review_at: None,
+        updated_at: Utc.timestamp_opt(updated_at, 0).single().unwrap(),
+    }
+}
+
+#[test]
+fn machine_index_skips_disabled_legacy_and_warpified_sessions() {
+    for (enabled, is_legacy_ssh, is_warpified_ssh) in [
+        (false, false, false),
+        (true, true, false),
+        (true, false, true),
+    ] {
+        assert_eq!(
+            load_index_with(
+                enabled,
+                is_legacy_ssh,
+                is_warpified_ssh,
+                || -> anyhow::Result<Vec<MachineMemory>> {
+                    panic!("gated sessions must not access the database")
+                }
+            ),
+            None
+        );
+    }
+}
+
+#[test]
+fn machine_index_empty_table_and_database_error_degrade_to_none() {
+    assert_eq!(
+        load_index_with(true, false, false, || Ok::<_, anyhow::Error>(Vec::new())),
+        None
+    );
+    assert_eq!(
+        load_index_with(true, false, false, || {
+            Err::<Vec<MachineMemory>, _>(anyhow!("database unavailable"))
+        }),
+        None
+    );
+}
+
+#[test]
+fn machine_index_loads_for_enabled_local_session() {
+    assert_eq!(
+        load_index_with(true, false, false, || {
+            Ok::<_, anyhow::Error>(vec![memory_at("web-01:22", "Linux", 1)])
+        }),
+        Some("- web-01:22: Linux".to_owned())
+    );
+}
+
+#[test]
+fn machine_index_uses_first_non_empty_line_and_unicode_summary_limit() {
+    let memories = vec![
+        memory_at("older:2222", "\n\n  nginx lives in /opt/nginx  \nmore", 1),
+        memory_at(
+            "newest:22",
+            format!(
+                "\n  {}  \nignored",
+                "机".repeat(INDEX_SUMMARY_MAX_CHARS + 1)
+            ),
+            2,
+        ),
+    ];
+
+    assert_eq!(
+        build_machine_index(&memories).unwrap(),
+        format!(
+            "- newest:22: {}\n- older:2222: nginx lives in /opt/nginx",
+            "机".repeat(INDEX_SUMMARY_MAX_CHARS)
+        )
+    );
+}
+
+#[test]
+fn machine_index_limits_machine_count() {
+    let memories = (0..INDEX_MAX_MACHINES + 1)
+        .map(|index| memory_at(format!("machine-{index}:22"), "Linux", index as i64))
+        .collect::<Vec<_>>();
+
+    let index = build_machine_index(&memories).unwrap();
+    assert_eq!(index.lines().count(), INDEX_MAX_MACHINES);
+    assert!(index.starts_with("- machine-30:22: Linux"));
+    assert!(index.contains("- machine-1:22: Linux"));
+    assert!(!index.contains("machine-0:22"));
+}
+
+#[test]
+fn machine_index_total_limit_preserves_unicode_boundaries() {
+    let memories = (0..INDEX_MAX_MACHINES)
+        .map(|index| {
+            memory_at(
+                format!("machine-{index}:22"),
+                "机".repeat(INDEX_SUMMARY_MAX_CHARS),
+                index as i64,
+            )
+        })
+        .collect::<Vec<_>>();
+
+    let index = build_machine_index(&memories).unwrap();
+    assert_eq!(index.chars().count(), INDEX_MAX_CHARS);
 }


### PR DESCRIPTION
## Description

实现 `specs/ssh-machine-memory/TECH.md` Task 5：在本地非 SSH 会话的 system prompt 注入 `<known_ssh_machines>`，支持按机器名理解用户意图。

- `RequestParams.machine_index` 在设置开启的本地会话加载
- 每台机器使用首个非空记忆行，单行最多 120 字符
- 按 `updated_at` 降序最多 30 台，总索引最多 3,000 字符，均按 Unicode 字符截断
- legacy 与 warpified SSH 会话均不注入索引
- prompt 明确只建议用户执行 `ssh`，Agent 不自动连接

## Testing / Task 5 验收自检

- [x] 本地/legacy/warpified/设置关闭 gating 测试通过
- [x] 空表与 DB 错误降级为无索引
- [x] 首个非空行、120 字符、30 台、3,000 字符限制均有 Unicode 测试
- [x] XML 文本转义与禁止自动连接提示测试通过
- [x] machine-memory 聚焦测试：30/30 通过
- [x] `cargo check`：通过；仅有既有未使用参数警告
- [x] `warp` 全量 nextest：3,625 通过、101 个既有基线失败、10 跳过；相对 Task 4 基线新增 8 个通过，失败集合不变
- [ ] 手工自然语言询问 `web-01` 的模型行为：未运行；需要交互式 Zap/模型

## Spec alignment

无设计偏离。

## Server API dependencies

无。

## Agent Mode

- [x] Zap Agent Mode - This PR was created via Zap AI Agent Mode
