### PR TITLE
fix(ai/agent): pager 包裹不再吞掉 heredoc 结束符导致 agent 卡死

### DIFF
--- a/app/src/ai/blocklist/action_model/execute/shell_command.rs
+++ b/app/src/ai/blocklist/action_model/execute/shell_command.rs
@@ -255,26 +255,7 @@ impl ShellCommandExecutor {
     /// 即便上述都失效,`action_result_future` 的 `MAX_UNTIL_COMPLETION_DURATION` 兜底
     /// 会保证 agent 不会**永久**挂起。
     fn turn_off_pager_for_command(&self, command: &String, ctx: &mut ModelContext<Self>) -> String {
-        match self.active_session.as_ref(ctx).shell_type(ctx) {
-            // 子壳里 export,子壳退出码 = 最后一条命令的退出码,从而保留真实 $?。
-            // 先 unset 清理继承自父 shell 的 PAGER/GIT_PAGER/MANPAGER,再 export=cat。
-            Some(ShellType::Zsh) | Some(ShellType::Bash) => format!(
-                "(unset PAGER GIT_PAGER MANPAGER; export PAGER=cat GIT_PAGER=cat MANPAGER=cat GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=core.pager GIT_CONFIG_VALUE_0=cat; {command})"
-            ),
-            // fish: set -lx 在 begin/end 块内是局部 export, $status 取最后一条命令。
-            // 用 `set -e` 先清掉继承变量,再 `set -lx` 赋 cat。
-            Some(ShellType::Fish) => format!(
-                "begin; set -e PAGER; set -e GIT_PAGER; set -e MANPAGER; set -lx PAGER cat; set -lx GIT_PAGER cat; set -lx MANPAGER cat; set -lx GIT_CONFIG_COUNT 1; set -lx GIT_CONFIG_KEY_0 core.pager; set -lx GIT_CONFIG_VALUE_0 cat; {command}; end"
-            ),
-            // pwsh: script block 局部 $env: 不污染外层会话, $LASTEXITCODE 透出。
-            // Remove-Item Env: 清理继承值,再赋 cat;对不存在变量用 -ErrorAction SilentlyContinue。
-            Some(ShellType::PowerShell) => format!(
-                "& {{ Remove-Item Env:PAGER -ErrorAction SilentlyContinue; Remove-Item Env:GIT_PAGER -ErrorAction SilentlyContinue; Remove-Item Env:MANPAGER -ErrorAction SilentlyContinue; $env:PAGER='cat'; $env:GIT_PAGER='cat'; $env:MANPAGER='cat'; $env:GIT_CONFIG_COUNT='1'; $env:GIT_CONFIG_KEY_0='core.pager'; $env:GIT_CONFIG_VALUE_0='cat'; {command} }}"
-            ),
-            // 未知 shell 无法安全装饰,直接放过 —— 此路径下 pager 抑制完全无效,只能
-            // 依靠 MAX_UNTIL_COMPLETION_DURATION 兜底超时避免永久挂起。
-            None => command.clone(),
-        }
+        wrap_command_without_pager(self.active_session.as_ref(ctx).shell_type(ctx), command)
     }
 
     pub(super) fn execute(
@@ -757,6 +738,69 @@ impl ShellCommandExecutor {
         _ctx: &mut ModelContext<Self>,
     ) -> BoxFuture<'static, ()> {
         futures::future::ready(()).boxed()
+    }
+}
+
+/// bash/zsh 的 pager 抑制前缀。子壳里 export,子壳退出码 = 最后一条命令的退出码,
+/// 从而保留真实 `$?`。先 unset 清理继承自父 shell 的 PAGER/GIT_PAGER/MANPAGER,再 export=cat。
+const POSIX_NO_PAGER_PRELUDE: &str = "unset PAGER GIT_PAGER MANPAGER; export PAGER=cat GIT_PAGER=cat MANPAGER=cat GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=core.pager GIT_CONFIG_VALUE_0=cat";
+
+/// fish: `set -lx` 在 begin/end 块内是局部 export,`$status` 取最后一条命令。
+/// 用 `set -e` 先清掉继承变量,再 `set -lx` 赋 cat。
+const FISH_NO_PAGER_PRELUDE: &str = "set -e PAGER; set -e GIT_PAGER; set -e MANPAGER; set -lx PAGER cat; set -lx GIT_PAGER cat; set -lx MANPAGER cat; set -lx GIT_CONFIG_COUNT 1; set -lx GIT_CONFIG_KEY_0 core.pager; set -lx GIT_CONFIG_VALUE_0 cat";
+
+/// pwsh: script block 局部 `$env:` 不污染外层会话,`$LASTEXITCODE` 透出。
+/// `Remove-Item Env:` 清理继承值,再赋 cat;对不存在变量用 `-ErrorAction SilentlyContinue`。
+const PWSH_NO_PAGER_PRELUDE: &str = "Remove-Item Env:PAGER -ErrorAction SilentlyContinue; Remove-Item Env:GIT_PAGER -ErrorAction SilentlyContinue; Remove-Item Env:MANPAGER -ErrorAction SilentlyContinue; $env:PAGER='cat'; $env:GIT_PAGER='cat'; $env:MANPAGER='cat'; $env:GIT_CONFIG_COUNT='1'; $env:GIT_CONFIG_KEY_0='core.pager'; $env:GIT_CONFIG_VALUE_0='cat'";
+
+/// 把 `command` 包进"禁用 pager"的作用域里,见 [`ShellCommandExecutor::turn_off_pager_for_command`]。
+///
+/// **不变式:多行命令的闭合 token(`)` / `end` / `}`)必须独占一行。**
+///
+/// 反例:agent 发 `python3 - <<'PY' … PY`,朴素拼接会得到 `…\nPY)`。heredoc 结束符
+/// 要求独占一行,`PY)` 不再匹配,shell 于是永远停在 PS2 续行提示符上等那一行 `PY`
+/// —— 命令永不结束 → precmd 不触发 → `ActionResultDelay::UntilCompletion` 一路挂到
+/// `MAX_UNTIL_COMPLETION_DURATION`(30 分钟),期间 `is_active_and_long_running()` 守卫
+/// 还会把 agent 后续所有命令打成 `CancelledBeforeExecution`,表现为整个 agent 卡死。
+/// 以尾随 `#` 注释结尾的命令是同一类破绽(闭合 token 被注释掉)。
+///
+/// 只在命令**本身已经是多行**时才切到多行包裹形态:单行命令保持原有单行字节形态,
+/// 避免在不支持 bracketed paste 的 shell(如 macOS 自带 bash 3.2)上被
+/// `bytes_to_execute_command` 的 `\n` → `\r` 替换拆成多个 block。多行命令在那些 shell
+/// 上本来就已经被拆分,本函数不会让情况变差。
+fn wrap_command_without_pager(shell_type: Option<ShellType>, command: &str) -> String {
+    // 命令尾部的换行/空白会让闭合 token 前多出空行,无语义影响但污染 blocklist 显示。
+    let command = command.trim_end();
+    let is_multiline = command.contains('\n');
+
+    match shell_type {
+        Some(ShellType::Zsh) | Some(ShellType::Bash) => {
+            let prelude = POSIX_NO_PAGER_PRELUDE;
+            if is_multiline {
+                format!("({prelude}\n{command}\n)")
+            } else {
+                format!("({prelude}; {command})")
+            }
+        }
+        Some(ShellType::Fish) => {
+            let prelude = FISH_NO_PAGER_PRELUDE;
+            if is_multiline {
+                format!("begin; {prelude}\n{command}\nend")
+            } else {
+                format!("begin; {prelude}; {command}; end")
+            }
+        }
+        Some(ShellType::PowerShell) => {
+            let prelude = PWSH_NO_PAGER_PRELUDE;
+            if is_multiline {
+                format!("& {{ {prelude}\n{command}\n}}")
+            } else {
+                format!("& {{ {prelude}; {command} }}")
+            }
+        }
+        // 未知 shell 无法安全装饰,直接放过 —— 此路径下 pager 抑制完全无效,只能
+        // 依靠 MAX_UNTIL_COMPLETION_DURATION 兜底超时避免永久挂起。
+        None => command.to_owned(),
     }
 }
 

--- a/app/src/ai/blocklist/action_model/execute/shell_command_tests.rs
+++ b/app/src/ai/blocklist/action_model/execute/shell_command_tests.rs
@@ -163,3 +163,61 @@ fn preemption_logic_covers_until_completion_timeout() {
         DurationDelay(Duration::from_secs(1))
     ));
 }
+
+/// 复现挂死案例:heredoc 结束符必须保持独占一行,闭合 `)` 不能被拼到它后面。
+/// 拼成 `PY)` 后 shell 永远等不到结束符,停在 PS2 上,命令永不结束。
+#[test]
+fn multiline_heredoc_keeps_delimiter_and_closer_on_their_own_lines() {
+    let command = "python3 - <<'PY'\nprint('ok')\nPY";
+
+    for shell in [ShellType::Bash, ShellType::Zsh] {
+        let wrapped = wrap_command_without_pager(Some(shell), command);
+        let lines: Vec<&str> = wrapped.lines().collect();
+
+        assert_eq!(
+            lines[lines.len() - 2],
+            "PY",
+            "heredoc 结束符被污染: {wrapped}"
+        );
+        assert_eq!(lines[lines.len() - 1], ")", "闭合括号未独占一行: {wrapped}");
+        assert!(wrapped.contains("PAGER=cat"), "pager 抑制丢失: {wrapped}");
+    }
+}
+
+/// 同一类破绽:命令以尾随 `#` 注释结尾时,闭合 token 会被注释掉。
+#[test]
+fn multiline_trailing_comment_does_not_swallow_closer() {
+    let command = "echo start\necho done # 收尾";
+
+    assert!(wrap_command_without_pager(Some(ShellType::Bash), command).ends_with("\n)"));
+    assert!(wrap_command_without_pager(Some(ShellType::Fish), command).ends_with("\nend"));
+    assert!(wrap_command_without_pager(Some(ShellType::PowerShell), command).ends_with("\n}"));
+}
+
+/// 单行命令必须保持原有的单行形态:`bytes_to_execute_command` 在不支持 bracketed
+/// paste 的 shell 上会把 `\n` 换成 `\r`,多加换行会把一条命令拆成多个 block。
+#[test]
+fn single_line_command_stays_on_one_line() {
+    let command = "cargo check";
+
+    for shell in [
+        ShellType::Bash,
+        ShellType::Zsh,
+        ShellType::Fish,
+        ShellType::PowerShell,
+    ] {
+        let wrapped = wrap_command_without_pager(Some(shell), command);
+        assert!(
+            !wrapped.contains('\n'),
+            "{shell:?} 单行命令被拆行: {wrapped}"
+        );
+        assert!(wrapped.contains(command), "{shell:?} 命令丢失: {wrapped}");
+    }
+}
+
+/// 未知 shell 无法安全装饰,原样放过。
+#[test]
+fn unknown_shell_passes_command_through() {
+    let command = "python3 - <<'PY'\nprint('ok')\nPY";
+    assert_eq!(wrap_command_without_pager(None, command), command);
+}


### PR DESCRIPTION
## Description

修复 Agent 执行含 heredoc 的多行命令时整个会话卡死的问题。

`turn_off_pager_for_command` 用裸文本拼接把闭合 token 粘到命令最后一个字符后面。命令最后一行是 heredoc 结束符时（agent 写/改文件的常见写法），拼出来是这样：

```
(unset PAGER GIT_PAGER MANPAGER; export PAGER=cat …; python3 - <<'PY'
from pathlib import Path
…
PY)
```

heredoc 结束符只有独占一行时才被识别。`PY)` 不匹配，shell 于是永远停在 PS2 续行提示符上等那一行 `PY`。

连锁反应：

- 命令永不结束 → precmd 不触发 → block 停在非 finished 状态
- `ActionResultDelay::UntilCompletion` 一路挂到 `MAX_UNTIL_COMPLETION_DURATION`（30 分钟）
- 期间 `active_block().is_active_and_long_running()` 恒为真，`RequestCommandOutput` 全部短路成 `CancelledBeforeExecution`

用户看到的就是整个 agent 会话死掉。Ctrl-C 救不回来——此时 shell 在读续行输入，`^C` 只取消当前输入行，`(` 仍未闭合。**输出最后一行是 `^C` 就是这个 bug 的指纹。**

不止 heredoc：命令最后一行以 `#` 注释结尾时闭合 token 被注释掉，属于同一类破绽。四个 shell 分支（bash/zsh 的 `)`、fish 的 `end`、pwsh 的 `}`）形状相同，PowerShell here-string（`@'` … `'@`）也有同样的行位置要求。

### 改动

让闭合 token 独占一行，**只对本身已经是多行的命令**：

```rust
// 多行
format!("({prelude}\n{command}\n)")
// 单行:字节不变
format!("({prelude}; {command})")
```

单行路径刻意保持字节级不变。把单行命令变成两行，在不支持 bracketed paste 的 shell（如 macOS 自带 bash 3.2）上会被 `bytes_to_execute_command` 的 `\n` → `\r` 替换拆成多个 block，而 agent mode 假定一条命令一个 block。多行命令在那些 shell 上本来就已经被拆分，本改动不会让情况变差。

装饰逻辑从 `&self` 方法抽成自由函数 `wrap_command_without_pager(Option<ShellType>, &str)` 以便单测，原方法退化为一行委托。

### 已知未修

**单行**命令以 `#` 注释结尾时（`git log # 看看历史`）仍会吞掉闭合 token，同样挂死。

不修的理由：修它需要让单行命令也走多行形态，会把上面那个 bracketed paste 拆块的风险扩散到**所有**被装饰的命令、所有 shell 上——把一个罕见故障换成一个面很广的回归风险，取舍上不划算。

而且这个组合实际上基本不可达：装饰只在 `wait_until_completion=true` 时触发，一条单行命令在这条路径上还要以尾随注释结尾，我们没见过。相比之下多行 heredoc 是 agent 写文件的常规写法，这次就是这么撞上的。

### 上游

同一个 bug 在 `warpdotdev/warp` master 上同样存在（三个分支全中，只是触发条件更窄：要 `uses_pager=true` 且 `wait_until_completion=true`）。已提上游 issue：https://github.com/warpdotdev/warp/issues/14324

## Testing

新增 4 个单测（`shell_command_tests.rs`）：

- `multiline_heredoc_keeps_delimiter_and_closer_on_their_own_lines` — heredoc 结束符与闭合括号各自独占一行，回归锁
- `multiline_trailing_comment_does_not_swallow_closer` — 覆盖 bash/fish/pwsh 三个分支
- `single_line_command_stays_on_one_line` — 钉死单行不换行
- `unknown_shell_passes_command_through`

另外在 bash 5 上直接验证了 shell 层行为（脱离 Zap）：

```console
# 修复前:闭合括号粘在结束符后面
$ printf "(export PAGER=cat; python3 - <<'PY'\nprint('ok')\nPY)\n" > /tmp/before.sh
$ bash /tmp/before.sh
/tmp/before.sh: line 3: warning: here-document at line 1 delimited by end-of-file (wanted `PY')
/tmp/before.sh: line 4: syntax error: unexpected end of file from `(' command on line 1

# 修复后:闭合括号独占一行
$ printf "(export PAGER=cat; python3 - <<'PY'\nimport os; print('PAGER=' + os.environ['PAGER'])\nPY\n)\n" > /tmp/after.sh
$ bash /tmp/after.sh
PAGER=cat
```

写进脚本时 EOF 会终止 heredoc，所以报语法错误；PTY 里 stdin 不会 EOF，所以真实症状是无限挂起而非报错。退出码透传也验证过（子壳里 `sys.exit(7)` → `$? == 7`），pager 抑制仍生效。

- [x] 聚焦测试 `ai::blocklist::action_model::execute::shell_command`：10/10 通过
- [x] `cargo fmt --check`：改动文件干净
- [x] 全量 nextest 基线 diff：见下

`cargo nextest run --no-fail-fast -p warp`，同一台机器上分别跑 main 和本分支：

| | 总数 | 通过 | 失败 | 跳过 |
|---|---|---|---|---|
| `main` 基线 | 3730 | 3650 | 80 | 10 |
| 本分支 | 3734 | 3654 | 80 | 10 |

- 失败测试**名称集合逐条比对完全一致**（80 → 80，新增 0，消失 0），80 个均为 main 上的既有失败
- 新增的 4 个测试全部通过（+4 总数、+4 通过）

> 注：仓库 AGENTS.md 给的是 `--workspace` 范围，但那会带上 `integration` crate 的 `ui_tests`，会真的拉起 Zap GUI 窗口。本改动完全落在 `warp` 包内，所以按 PR #5 的惯例用 `-p warp` 范围做基线 diff。

## Server API dependencies

无。

## Agent Mode

- [x] Zap Agent Mode - This PR was created via Zap AI Agent Mode

## Changelog Entries for Stable

CHANGELOG-BUG-FIX: 修复 Agent 执行以 heredoc 结尾的多行命令时，shell 卡在续行提示符导致整个会话挂死的问题。
